### PR TITLE
Fix jsonObject & unicodeJsonObject type signatures

### DIFF
--- a/src/Arbitrary.re
+++ b/src/Arbitrary.re
@@ -277,9 +277,9 @@ module Objects = {
     (~settings: settings=?, unit) => arbitrary(Js.Dict.t(any)) =
     "object";
   [@bs.module "fast-check"]
-  external jsonObject: int => arbitrary(Js.Dict.t(Js.Json.t)) = "jsonObject";
+  external jsonObject: int => arbitrary(Js.Json.t) = "jsonObject";
   [@bs.module "fast-check"]
-  external unicodeJsonObject: int => arbitrary(Js.Dict.t(Js.Json.t)) =
+  external unicodeJsonObject: int => arbitrary(Js.Json.t) =
     "unicodeJsonObject";
 
   [@bs.module "fast-check"]

--- a/test/ArbitraryTest.re
+++ b/test/ArbitraryTest.re
@@ -175,8 +175,28 @@ describe("complex built-in arbitraries", () => {
         constTrue,
       ),
     );
+  });
+
+  it("json", () => {
+    // Despite the names, these are really *any* JSON value
     FcAssert.sync(property1(Objects.jsonObject(5), eq));
     FcAssert.sync(property1(Objects.unicodeJsonObject(5), eq));
+    let checkProducesJsonValue = arb => {
+      open Js.Json;
+      let checkProduces = kind =>
+        SyncUnit.property1(arb, v => Property.pre(v->test(kind)))
+        ->SyncUnit.assertParams(
+            Parameters.t(~maxSkipsPerRun=1000, ~numRuns=1, ()),
+          );
+      checkProduces(String);
+      checkProduces(Number);
+      checkProduces(Object);
+      checkProduces(Array);
+      checkProduces(Boolean);
+      checkProduces(Null);
+    };
+    checkProducesJsonValue(Objects.jsonObject(1));
+    checkProducesJsonValue(Objects.unicodeJsonObject(1));
   });
 
   it("letrec", () => {


### PR DESCRIPTION
Despite the names and superficial appearances, these arbitraries emit JSON values, not just JSON objects.